### PR TITLE
Add support for trading on multiple admin specified markets simultaneously 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 				"dsznajder.es7-react-js-snippets",
 				"xabikos.JavaScriptSnippets",
 				"esbenp.prettier-vscode",
-				"ChakrounAnas.turbo-console-log"
+				"ChakrounAnas.turbo-console-log",
+				"GitHub.copilot"
 			]
 		}
 	},

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -129,9 +129,9 @@ app.put(
   handleErrors(
     checkAuth(async (req, res, email) => {
       const { gameId } = req.params;
-      const { markets, name, desc, media } = req.body;
+      const { sections, name, desc, media } = req.body;
       await assertGameOwner(email, gameId);
-      await updateGame(gameId, markets, name, desc, media);
+      await updateGame(gameId, sections, name, desc, media);
       return res.status(200).send({});
     })
   )

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -226,8 +226,8 @@ app.put(
   '/game/:teamId/submit',
   handleErrors(async (req, res) => {
     const { teamId } = req.params;
-    const { bid, ask } = req.body;
-    await setTeamBidAsk(teamId, bid, ask);
+    const { bid, ask, marketIndex } = req.body;
+    await setTeamBidAsk(teamId, bid, ask, marketIndex);
     return res.status(200).send({ status: 200 });
   })
 );

--- a/backend/src/service.js
+++ b/backend/src/service.js
@@ -563,7 +563,9 @@ export const trade = (sessionId, marketPos) =>
       return reject(new InputError('Game session has not begun'));
     } else {
       const teamIds = Object.keys(teams);
-
+      if (teamIds.length <= 0) {
+        resolve();
+      }
       const marketsLength =
         teams[teamIds[0]].teamAnswers[session.position].markets.length;
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -36,6 +36,15 @@ const theme = createTheme({
       darker: '#513b7a',
     },
   },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 650,
+      md: 900,
+      lg: 1300,
+      xl: 1536,
+    },
+  },
 });
 
 const App = () => {

--- a/frontend/src/components/AdvanceGameBtn.jsx
+++ b/frontend/src/components/AdvanceGameBtn.jsx
@@ -14,6 +14,7 @@ const AdvanceGameBtn = ({
   isEnd,
   unsetTradeBtn,
   isDisabled,
+  callback,
 }) => {
   const { isModalShown, toggleModal } = useModal();
   const { sessionId } = useParams();
@@ -33,6 +34,7 @@ const AdvanceGameBtn = ({
       onClick={() => {
         advanceSession();
         unsetTradeBtn && unsetTradeBtn();
+        callback();
       }}
       disabled={isDisabled}
       startIcon={!isSessionStart ? <PlayArrowIcon /> : <ArrowForwardIcon />}

--- a/frontend/src/components/AdvanceGameBtn.jsx
+++ b/frontend/src/components/AdvanceGameBtn.jsx
@@ -13,6 +13,7 @@ const AdvanceGameBtn = ({
   setIsSessionStart,
   isEnd,
   unsetTradeBtn,
+  isDisabled,
 }) => {
   const { isModalShown, toggleModal } = useModal();
   const { sessionId } = useParams();
@@ -33,6 +34,7 @@ const AdvanceGameBtn = ({
         advanceSession();
         unsetTradeBtn && unsetTradeBtn();
       }}
+      disabled={isDisabled}
       startIcon={!isSessionStart ? <PlayArrowIcon /> : <ArrowForwardIcon />}
       sx={{ my: 2 }}
     >
@@ -46,7 +48,7 @@ const AdvanceGameBtn = ({
         modalTitle="Game Complete"
       >
         <Box>
-          <Typography variant="h6">
+          <Typography variant="h6" sx={{ mb: 2 }}>
             Would you like to view the session results?
           </Typography>
           <RedirectBtn

--- a/frontend/src/components/BidAskPanel.jsx
+++ b/frontend/src/components/BidAskPanel.jsx
@@ -12,7 +12,16 @@ import GroupIcon from '@mui/icons-material/Group';
 import PaidOutlinedIcon from '@mui/icons-material/PaidOutlined';
 import RequestPageOutlinedIcon from '@mui/icons-material/RequestPageOutlined';
 
-const BidAskPanel = ({ teamId, teamName, balance, contracts, position }) => {
+const BidAskPanel = ({
+  teamId,
+  teamName,
+  balance,
+  contracts,
+  position,
+  marketIndex,
+  lastBid,
+  lastAsk,
+}) => {
   const [isTradeSuccess, setIsTradeSuccess] = useState(false);
   const [bid, setBid] = useState('');
   const [ask, setAsk] = useState('');
@@ -25,9 +34,10 @@ const BidAskPanel = ({ teamId, teamName, balance, contracts, position }) => {
     const res = await fetchAPIRequest(`/game/${teamId}/submit`, 'PUT', {
       bid,
       ask,
+      marketIndex,
     });
 
-    res.status === 200 && setIsTradeSuccess(true);
+    // res.status === 200 && setIsTradeSuccess(true);
   };
 
   return (
@@ -91,7 +101,8 @@ const BidAskPanel = ({ teamId, teamName, balance, contracts, position }) => {
           sx={{ mr: 1 }}
           autoFocus
           onChange={(event) => setBid(event.target.value)}
-          value={bid}
+          disabled={lastBid !== 0 || lastAsk !== 0}
+          value={lastBid ? lastBid : bid}
         />
         <TextField
           color="success"
@@ -99,102 +110,19 @@ const BidAskPanel = ({ teamId, teamName, balance, contracts, position }) => {
           type="number"
           sx={{ ml: 1 }}
           onChange={(event) => setAsk(event.target.value)}
-          value={ask}
+          disabled={lastBid !== 0 || lastAsk !== 0}
+          value={lastAsk ? lastAsk : ask}
         />
       </Box>
       <Button
         variant="contained"
-        disabled={isTradeSuccess}
+        disabled={lastBid !== 0 || lastAsk !== 0}
         onClick={submitSpread}
         sx={{ mx: 'auto', px: 5, mt: 2 }}
       >
         Submit
       </Button>
     </Box>
-    // <Box
-    //   sx={{
-    //     backgroundColor: 'white',
-    //     boxShadow: 3,
-    //     borderRadius: 3,
-    //     p: 3,
-    //     display: 'flex',
-    //     flexDirection: 'column',
-    //     flex: '1 1 auto',
-    //     width: { xs: '80%', md: '70%' },
-    //     maxWidth: 500,
-    //     m: 'auto',
-    //     mb: 3,
-    //   }}
-    // >
-    //   <Typography
-    //     variant="h5"
-    //     sx={{
-    //       // width: { xs: 2, sm: 100, md: 150, lg: 170 },
-    //       // textOverflow: 'ellipsis',
-    //       // overflow: 'hidden',
-    //       // whiteSpace: 'nowrap',
-    //       wordBreak: 'break-all',
-    //       display: 'flex',
-    //       alignItems: 'center',
-    //     }}
-    //   >
-    //     <GroupIcon fontSize="large" sx={{ mr: 1 }} />
-    //     {teamName}
-    //   </Typography>
-    //   {isTradeSuccess && (
-    //     <Typography color="text.secondary">Awaiting next round</Typography>
-    //   )}
-    //   {isTradeSuccess && <LinearProgress />}
-    //   <Divider sx={{ my: 2 }} />
-    //   <Box sx={{ display: 'flex', justifyContent: 'space-around', mb: 2 }}>
-    //     <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center' }}>
-    //       <PaidTwoToneIcon fontSize="large" sx={{ mr: 1 }} />
-    //       {balance}
-    //     </Typography>
-    //     <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center' }}>
-    //       <RequestPageTwoToneIcon
-    //         fontSize="large"
-    //         color="primary"
-    //         sx={{ mr: 1 }}
-    //       />{' '}
-    //       {contracts} contracts
-    //     </Typography>
-    //   </Box>
-    //   <Box sx={{ display: 'flex', justifyContent: 'space-evenly', mb: 2 }}>
-    //     <TextField
-    //       color="error"
-    //       label="Bid Price"
-    //       type="number"
-    //       inputProps={{
-    //         style: { fontSize: 20, fontFamily: 'monospace' },
-    //       }}
-    //       sx={{ mr: 1 }}
-    //       autoFocus
-    //       onChange={(event) => setBid(event.target.value)}
-    //       value={bid}
-    //     />
-    //     <TextField
-    //       color="success"
-    //       label="Ask Price"
-    //       type="number"
-    //       inputProps={{
-    //         style: { fontSize: 20, fontFamily: 'monospace' },
-    //       }}
-    //       sx={{ ml: 1 }}
-    //       onChange={(event) => setAsk(event.target.value)}
-    //       value={ask}
-    //     />
-    //   </Box>
-    //   <Button
-    //     size="large"
-    //     variant="contained"
-    //     disabled={isTradeSuccess}
-    //     onClick={submitSpread}
-    //     sx={{ mx: 4 }}
-    //   >
-    //     Submit
-    //   </Button>
-    // </Box>
   );
 };
 export default BidAskPanel;

--- a/frontend/src/components/BidAskPanel.jsx
+++ b/frontend/src/components/BidAskPanel.jsx
@@ -31,7 +31,7 @@ const BidAskPanel = ({
   }, [position]);
 
   const submitSpread = async () => {
-    const res = await fetchAPIRequest(`/game/${teamId}/submit`, 'PUT', {
+    await fetchAPIRequest(`/game/${teamId}/submit`, 'PUT', {
       bid,
       ask,
       marketIndex,

--- a/frontend/src/components/GameCard.jsx
+++ b/frontend/src/components/GameCard.jsx
@@ -8,7 +8,7 @@ import {
   Skeleton,
   Box,
 } from '@mui/material';
-import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import EventIcon from '@mui/icons-material/Event';
 import { fetchAPIRequest } from '../helpers.js';
 import banner from '../assets/mtg-image.png';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
@@ -73,7 +73,6 @@ const GameCard = ({ gameId, isLoading, setCardCount }) => {
           >
             <Typography
               sx={{
-                fontSize: 20,
                 display: 'flex',
                 alignItems: 'center',
                 m: 0,
@@ -81,8 +80,8 @@ const GameCard = ({ gameId, isLoading, setCardCount }) => {
               color="text.secondary"
               gutterBottom
             >
-              <AccessTimeIcon sx={{ mr: 0.5 }} />
-              {cardData?.rounds?.length}s
+              <EventIcon sx={{ mr: 0.5, color: 'text.secondary' }} />
+              {new Date(cardData?.createdAt).toLocaleDateString()}
             </Typography>
 
             {gameSession && (

--- a/frontend/src/components/GameTransition.jsx
+++ b/frontend/src/components/GameTransition.jsx
@@ -1,6 +1,6 @@
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 
-const GameTransition = ({ message, isTransition }) => {
+const GameTransition = ({ isTransition }) => {
   return (
     <Box
       sx={{

--- a/frontend/src/components/GameTransition.jsx
+++ b/frontend/src/components/GameTransition.jsx
@@ -1,0 +1,24 @@
+import { Box, Typography } from '@mui/material';
+
+const GameTransition = ({ message, isTransition }) => {
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        width: '100vw',
+        height: '100vh',
+        top: 0,
+        left: 0,
+        display: 'flex',
+        visibility: isTransition ? 'visible' : 'hidden',
+        opacity: isTransition ? 1 : 0,
+        transition: 'visibility 0.5s ease-out, opacity 0.5s ease-out',
+        justifyContent: 'center',
+        alignItems: 'center',
+        zIndex: 5,
+        backgroundColor: '#ffffff',
+      }}
+    ></Box>
+  );
+};
+export default GameTransition;

--- a/frontend/src/components/GameTriggerBtn.jsx
+++ b/frontend/src/components/GameTriggerBtn.jsx
@@ -61,7 +61,7 @@ const GameTriggerBtn = ({
           )}
           <Typography variant="h6" textAlign="center" sx={{ mb: 2 }}>
             {isStart
-              ? `Players can join at \r\n ${window.location.origin.toString()}/join/${gameSession}.`
+              ? `Players can join at \r\n ${window.location.origin.toString()}/join/${gameSession}`
               : 'Would you like to view the session results?'}
           </Typography>
           {isStart ? (

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -12,3 +12,4 @@ export { default as TeamPanel } from './TeamPanel.jsx';
 export { default as TradePanel } from './TradePanel.jsx';
 export { default as BidAskPanel } from './BidAskPanel.jsx';
 export { default as Notification } from './Notification.jsx';
+export { default as GameTransition } from './GameTransition.jsx';

--- a/frontend/src/pages/AdminSessionPage.jsx
+++ b/frontend/src/pages/AdminSessionPage.jsx
@@ -128,7 +128,7 @@ const AdminSessionPage = () => {
     const gameInterval = setInterval(() => {
       getGameStatus(gameInterval);
     }, 1000);
-    return () => clearTimeout(gameInterval);
+    return () => clearInterval(gameInterval);
   }, [sessionId, alertCtx]);
 
   const renderQuestions = (questions) => {

--- a/frontend/src/pages/AdminSessionPage/AdminSessionMain.jsx
+++ b/frontend/src/pages/AdminSessionPage/AdminSessionMain.jsx
@@ -1,0 +1,64 @@
+import {
+  Box,
+  Typography,
+  Grid,
+  TextField,
+  Button,
+  CircularProgress,
+  Divider,
+  Skeleton,
+  LinearProgress,
+  FormControl,
+} from '@mui/material';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import { useEffect, useState, useContext } from 'react';
+import { fetchAPIRequest } from '../../helpers';
+import { useParams } from 'react-router-dom';
+import AdvanceGameBtn from '../../components/AdvanceGameBtn';
+import TeamStats from '../GameHistoryPage/TeamStats';
+import { AlertContext } from '../../contexts/NotificationContext';
+import { EditGameSection } from '../EditGamePage';
+
+const AdminSessionMain = ({
+  gameId,
+  position,
+  questions,
+  isSessionStart,
+  setIsSessionStart,
+}) => {
+  const [hasTraded, setHasTraded] = useState(false);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'space-between',
+        mb: 5,
+      }}
+    >
+      <Typography
+        variant="h4"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          whiteSpace: 'nowrap',
+          fontSize: { xs: 24, md: 34 },
+        }}
+      >
+        <AdminPanelSettingsIcon sx={{ width: 50, height: 50 }} />
+        Session Controls
+      </Typography>
+      {isSessionStart && (
+        <AdvanceGameBtn
+          gameId={gameId}
+          isSessionStart={isSessionStart}
+          setIsSessionStart={setIsSessionStart}
+          isEnd={position === questions.length - 1}
+          unsetTradeBtn={() => setHasTraded(false)}
+        />
+      )}
+    </Box>
+  );
+};
+export default AdminSessionMain;

--- a/frontend/src/pages/AdminSessionPage/AdminSessionMarketSelector.jsx
+++ b/frontend/src/pages/AdminSessionPage/AdminSessionMarketSelector.jsx
@@ -1,0 +1,27 @@
+import { Box, InputLabel, Select, FormControl, MenuItem } from '@mui/material';
+
+const AdminSessionMarketSelector = ({ current, setSelectedMarketIndex }) => {
+  return (
+    <Box sx={{ maxWidth: 750, mt: 5, mx: 'auto' }}>
+      <FormControl fullWidth>
+        <InputLabel htmlFor="uncontrolled-select">Market</InputLabel>
+        <Select
+          defaultValue={0}
+          label="Market"
+          id="uncontrolled-select"
+          onChange={(event) => {
+            setSelectedMarketIndex(event.target.value);
+          }}
+        >
+          {current?.round &&
+            Object.keys(current.round).map((market, index) => (
+              <MenuItem key={index} value={index}>
+                {market}
+              </MenuItem>
+            ))}
+        </Select>
+      </FormControl>
+    </Box>
+  );
+};
+export default AdminSessionMarketSelector;

--- a/frontend/src/pages/AdminSessionPage/AdminSessionPage.jsx
+++ b/frontend/src/pages/AdminSessionPage/AdminSessionPage.jsx
@@ -18,6 +18,7 @@ import { AlertContext } from '../../contexts/NotificationContext';
 import { EditGameSection } from '../EditGamePage';
 import AdminSessionQuestionCard from './AdminSessionQuestionCard';
 import AdminSessionTradeArea from './AdminSessionTradeArea';
+import { GameTransition } from '../../components';
 
 const AdminSessionPage = () => {
   const { gameId } = useParams();
@@ -32,7 +33,7 @@ const AdminSessionPage = () => {
   const [current, setCurrent] = useState({});
   const alertCtx = useContext(AlertContext);
   const [gameData, setGameData] = useState({});
-
+  const [isTransition, setIsTransition] = useState(false);
   const [selectedMarketIndex, setSelectedMarketIndex] = useState(0);
 
   useEffect(() => {
@@ -42,6 +43,10 @@ const AdminSessionPage = () => {
     };
     fetchGameData();
   }, [gameId]);
+
+  useEffect(() => {
+    setIsTransition(false);
+  }, [position]);
 
   const processResults = (teams, marketIndex) => {
     const teamResults = Object.keys(teams)
@@ -213,6 +218,7 @@ const AdminSessionPage = () => {
         pt: 10,
       }}
     >
+      <GameTransition isTransition={isTransition} />
       <Box
         sx={{
           backgroundColor: '#fff',
@@ -270,6 +276,7 @@ const AdminSessionPage = () => {
                   isEnd={session.position === session.questions.length - 1}
                   isDisabled={current?.type === 'round' && !hasTraded}
                   unsetTradeBtn={() => setHasTraded(false)}
+                  callback={() => setIsTransition(true)}
                 />
               </Box>
               <AdminSessionQuestionCard
@@ -445,6 +452,7 @@ const AdminSessionPage = () => {
                   gameId={gameId}
                   isSessionStart={isSessionStart}
                   setIsSessionStart={setIsSessionStart}
+                  callback={() => {}}
                 />
               </Box>
               <Typography variant="h5" sx={{ fontSize: { xs: 16, md: 24 } }}>

--- a/frontend/src/pages/AdminSessionPage/AdminSessionPage.jsx
+++ b/frontend/src/pages/AdminSessionPage/AdminSessionPage.jsx
@@ -34,7 +34,6 @@ const AdminSessionPage = () => {
   const alertCtx = useContext(AlertContext);
   const [gameData, setGameData] = useState({});
   const [isTransition, setIsTransition] = useState(false);
-  const [selectedMarketIndex, setSelectedMarketIndex] = useState(0);
 
   useEffect(() => {
     const fetchGameData = async () => {
@@ -285,7 +284,7 @@ const AdminSessionPage = () => {
                 hasTraded={hasTraded}
                 initiateTrade={initiateTrade}
                 setHasTraded={setHasTraded}
-                selectedMarketIndex={selectedMarketIndex}
+                selectedMarketIndex={0}
               />
               {/* {current?.type !== 'section' && (
                 <AdminSessionMarketSelector

--- a/frontend/src/pages/AdminSessionPage/AdminSessionPage.jsx
+++ b/frontend/src/pages/AdminSessionPage/AdminSessionPage.jsx
@@ -49,7 +49,9 @@ const AdminSessionPage = () => {
   const processResults = (teams) => {
     const teamResults = Object.keys(teams)
       .map((teamId, index) => {
-        const trueValue = session.questions[session.position]?.trueValue;
+        const trueValue = Object.values(
+          session.questions[session.position].round
+        )[selectedMarketIndex];
         const balance =
           teams[teamId].teamAnswers[position].markets[selectedMarketIndex]
             .balance;

--- a/frontend/src/pages/AdminSessionPage/AdminSessionPage.jsx
+++ b/frontend/src/pages/AdminSessionPage/AdminSessionPage.jsx
@@ -3,9 +3,7 @@ import {
   Typography,
   Grid,
   TextField,
-  Button,
   CircularProgress,
-  Divider,
   Skeleton,
   LinearProgress,
   FormControl,
@@ -20,7 +18,6 @@ import { AlertContext } from '../../contexts/NotificationContext';
 import { EditGameSection } from '../EditGamePage';
 import AdminSessionQuestionCard from './AdminSessionQuestionCard';
 import AdminSessionTradeArea from './AdminSessionTradeArea';
-import AdminSessionMarketSelector from './AdminSessionMarketSelector';
 
 const AdminSessionPage = () => {
   const { gameId } = useParams();
@@ -46,18 +43,16 @@ const AdminSessionPage = () => {
     fetchGameData();
   }, [gameId]);
 
-  const processResults = (teams) => {
+  const processResults = (teams, marketIndex) => {
     const teamResults = Object.keys(teams)
       .map((teamId, index) => {
         const trueValue = Object.values(
           session.questions[session.position].round
-        )[selectedMarketIndex];
+        )[marketIndex];
         const balance =
-          teams[teamId].teamAnswers[position].markets[selectedMarketIndex]
-            .balance;
+          teams[teamId].teamAnswers[position].markets[marketIndex].balance;
         const contracts =
-          teams[teamId].teamAnswers[position].markets[selectedMarketIndex]
-            .contracts;
+          teams[teamId].teamAnswers[position].markets[marketIndex].contracts;
         const total =
           parseInt(contracts, 10) * parseFloat(trueValue, 10) +
           parseFloat(balance, 10);
@@ -225,7 +220,7 @@ const AdminSessionPage = () => {
           borderRadius: '10px 10px 0px 0px',
           boxShadow: 1,
           width: '100%',
-          px: { xs: 2, sm: 5 },
+          px: { xs: 2, sm: 2, lg: 2, xl: 5 },
           py: 7,
         }}
       >
@@ -273,6 +268,7 @@ const AdminSessionPage = () => {
                   isSessionStart={isSessionStart}
                   setIsSessionStart={setIsSessionStart}
                   isEnd={session.position === session.questions.length - 1}
+                  isDisabled={current?.type === 'round' && !hasTraded}
                   unsetTradeBtn={() => setHasTraded(false)}
                 />
               </Box>
@@ -284,20 +280,119 @@ const AdminSessionPage = () => {
                 setHasTraded={setHasTraded}
                 selectedMarketIndex={selectedMarketIndex}
               />
-              {current?.type !== 'section' && (
+              {/* {current?.type !== 'section' && (
                 <AdminSessionMarketSelector
                   current={current}
                   setSelectedMarketIndex={setSelectedMarketIndex}
                 />
-              )}
-              {current?.type === 'round' && (
+              )} */}
+              {/* {current?.type === 'round' && (
                 <AdminSessionTradeArea
                   teams={session.teams}
                   position={position}
                   selectedMarketIndex={selectedMarketIndex}
                 />
-              )}
-              <Grid container columns={12} spacing={3} sx={{ py: 3 }}>
+              )} */}
+
+              <Grid
+                container
+                columns={24}
+                columnSpacing={{ xs: 1, sm: 2, md: 3 }}
+                sx={{ mt: 4 }}
+              >
+                {current?.type === 'round' &&
+                  Object.keys(current.round).map((market, index) => {
+                    return (
+                      <Grid
+                        item
+                        xs={24}
+                        md={24}
+                        lg={12}
+                        xl={12}
+                        key={index}
+                        sx={{
+                          // border: '0.5px solid #41414111',
+                          borderRadius: '10px',
+                          mb: 7,
+                        }}
+                      >
+                        <Typography sx={{ mb: 1, fontSize: 18 }}>
+                          {market}
+                        </Typography>
+                        <AdminSessionTradeArea
+                          key={index}
+                          teams={session.teams}
+                          position={position}
+                          marketName={market}
+                          selectedMarketIndex={index}
+                        />
+                      </Grid>
+                    );
+                  })}
+              </Grid>
+
+              <Grid
+                container
+                columns={24}
+                columnSpacing={{ xs: 1, sm: 2, md: 3 }}
+                sx={{ mt: 4 }}
+              >
+                {current?.type === 'result' &&
+                  Object.keys(current.round).map((market, marketIndex) => {
+                    return (
+                      <Grid
+                        item
+                        xs={24}
+                        md={24}
+                        lg={12}
+                        xl={12}
+                        key={marketIndex}
+                        sx={{
+                          // border: '0.5px solid #41414111',
+                          borderRadius: '10px',
+                          mb: 7,
+                        }}
+                      >
+                        <Typography sx={{ mb: 1, fontSize: 18 }}>
+                          {market}
+                        </Typography>
+                        <Grid container columns={12} spacing={1}>
+                          {processResults(session.teams, marketIndex).map(
+                            (team, index) => {
+                              return (
+                                <Grid
+                                  item
+                                  xs={12}
+                                  sm={6}
+                                  md={6}
+                                  lg={6}
+                                  key={index}
+                                  sx={{
+                                    display: 'flex',
+                                    justifyContent: 'center',
+                                  }}
+                                >
+                                  <FormControl sx={{ width: '100%' }}>
+                                    <TeamStats
+                                      key={`team-stats-${index}`}
+                                      teamName={team.teamName}
+                                      balance={team.balance}
+                                      contracts={team.contracts}
+                                      isWinner={team.isWinner}
+                                      trueValue={team.trueValue}
+                                    />
+                                  </FormControl>
+                                </Grid>
+                              );
+                            }
+                          )}
+                        </Grid>
+                      </Grid>
+                    );
+                  })}
+              </Grid>
+
+              {/* <Grid container columns={12} spacing={3} sx={{ py: 3 }}>
                 {current?.type === 'result' &&
                   processResults(session.teams).map((team, index) => {
                     return (
@@ -322,7 +417,7 @@ const AdminSessionPage = () => {
                       </Grid>
                     );
                   })}
-              </Grid>
+              </Grid> */}
             </Box>
           ) : (
             <>

--- a/frontend/src/pages/AdminSessionPage/AdminSessionQuestionCard.jsx
+++ b/frontend/src/pages/AdminSessionPage/AdminSessionQuestionCard.jsx
@@ -1,0 +1,75 @@
+import { Box, Typography, Button, Divider } from '@mui/material';
+
+const AdminSessionQuestionCard = ({
+  current,
+  position,
+  hasTraded,
+  initiateTrade,
+  setHasTraded,
+  selectedMarketIndex,
+}) => {
+  return (
+    <Box
+      sx={{
+        boxShadow: 2,
+        borderRadius: '10px',
+        width: { xs: '70%', md: '50%' },
+        height: 'fit-content',
+        py: 4,
+        px: 4,
+        mx: 'auto',
+        border: current?.type === 'result' && '1px solid gold',
+      }}
+    >
+      <Typography variant="h6" color="text.secondary" sx={{ float: 'right' }}>
+        {position.toString()}
+      </Typography>
+
+      <Typography variant="h5">
+        {current?.type[0].toUpperCase() + current?.type.slice(1)}
+      </Typography>
+
+      <Typography color="text.secondary">{current?.name}</Typography>
+
+      <Divider sx={{ my: 2 }} />
+
+      {current?.type === 'round' && (
+        <Typography color="text.secondary">
+          {current?.round && Object.values(current?.round)[selectedMarketIndex]
+            ? Object.values(current?.round)[selectedMarketIndex]
+            : 'No hint given'}
+        </Typography>
+      )}
+
+      <Typography fontSize={18}>
+        {current?.type === 'result' && 'Please view the results below.'}
+      </Typography>
+
+      {current?.type === 'round' && (
+        <Box
+          sx={{
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            flexDirection: 'column',
+          }}
+        >
+          <Typography>Click the button to begin trading</Typography>
+          <Button
+            variant="contained"
+            disabled={hasTraded}
+            onClick={() => {
+              initiateTrade();
+              setHasTraded(true);
+            }}
+            size="large"
+            sx={{ maxWidth: '30%', mt: 2 }}
+          >
+            Trade
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+};
+export default AdminSessionQuestionCard;

--- a/frontend/src/pages/AdminSessionPage/AdminSessionTradeArea.jsx
+++ b/frontend/src/pages/AdminSessionPage/AdminSessionTradeArea.jsx
@@ -1,0 +1,48 @@
+import { Box, Grid, FormControl } from '@mui/material';
+import TeamStats from '../GameHistoryPage/TeamStats';
+
+const AdminSessionTradeArea = ({ teams, position, selectedMarketIndex }) => {
+  const processTeams = (marketIndex) => {
+    return Object.keys(teams).map((teamId) => {
+      return (
+        <Grid
+          item={true}
+          xs={12}
+          md={6}
+          lg={4}
+          key={teamId + 'item'}
+          sx={{ display: 'flex', justifyContent: 'center' }}
+        >
+          <FormControl sx={{ width: '100%' }}>
+            <TeamStats
+              key={`team-stats-${teamId}`}
+              teamName={teams[teamId].name}
+              balance={
+                teams[teamId].teamAnswers[position].markets[marketIndex].balance
+              }
+              contracts={
+                teams[teamId].teamAnswers[position].markets[marketIndex]
+                  .contracts
+              }
+              bid={
+                teams[teamId].teamAnswers[position].markets[marketIndex]?.bid
+              }
+              ask={
+                teams[teamId].teamAnswers[position].markets[marketIndex]?.ask
+              }
+            />
+          </FormControl>
+        </Grid>
+      );
+    });
+  };
+
+  return (
+    <Box>
+      <Grid container columns={12} spacing={3} sx={{ p: 5 }}>
+        {processTeams(selectedMarketIndex)}
+      </Grid>
+    </Box>
+  );
+};
+export default AdminSessionTradeArea;

--- a/frontend/src/pages/AdminSessionPage/AdminSessionTradeArea.jsx
+++ b/frontend/src/pages/AdminSessionPage/AdminSessionTradeArea.jsx
@@ -8,8 +8,9 @@ const AdminSessionTradeArea = ({ teams, position, selectedMarketIndex }) => {
         <Grid
           item={true}
           xs={12}
+          sm={6}
           md={6}
-          lg={4}
+          lg={6}
           key={teamId + 'item'}
           sx={{ display: 'flex', justifyContent: 'center' }}
         >
@@ -39,7 +40,7 @@ const AdminSessionTradeArea = ({ teams, position, selectedMarketIndex }) => {
 
   return (
     <Box>
-      <Grid container columns={12} spacing={3} sx={{ p: 5 }}>
+      <Grid container columns={12} spacing={1} sx={{}}>
         {processTeams(selectedMarketIndex)}
       </Grid>
     </Box>

--- a/frontend/src/pages/EditGamePage/EditGameMarket.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameMarket.jsx
@@ -156,8 +156,8 @@ const EditGameMarket = ({
         sx={{ ml: 4, mt: 2 }}
         disabled={isDisabled}
         onClick={() => {
-          // markets[selectedMarketIndex].rounds.push({ ...ROUND_PAYLOAD });
-          markets.forEach((market) => market.rounds.push({ ...ROUND_PAYLOAD }));
+          markets[selectedMarketIndex].rounds.push({ ...ROUND_PAYLOAD });
+          // markets.forEach((market) => market.rounds.push({ ...ROUND_PAYLOAD }));
           setMarkets([...markets]);
         }}
       >

--- a/frontend/src/pages/EditGamePage/EditGameMarket.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameMarket.jsx
@@ -94,7 +94,7 @@ const EditGameMarket = ({
                 setMarkets([...markets]);
               }, 300);
             }}
-            sx={{ p: 2, ml: 2 }}
+            sx={{ p: 2, ml: 2, opacity: 0.7 }}
           >
             <CloseIcon />
           </IconButton>
@@ -129,7 +129,7 @@ const EditGameMarket = ({
                     markets.forEach((market) => market.rounds.splice(index, 1));
                     setMarkets([...markets]);
                   }}
-                  sx={{ p: 2, ml: 2 }}
+                  sx={{ p: 2, ml: 2, opacity: 0.7 }}
                 >
                   <DeleteOutlineIcon />
                 </IconButton>

--- a/frontend/src/pages/EditGamePage/EditGameMarket.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameMarket.jsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  IconButton,
+  Tooltip,
+  Switch,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import CloseIcon from '@mui/icons-material/Close';
+
+const ROUND_PAYLOAD = {
+  hint: '',
+};
+
+const EditGameMarket = ({
+  name,
+  rounds,
+  trueValue,
+  selectedMarketIndex,
+  setSelectedMarketIndex,
+  markets,
+  setMarkets,
+}) => {
+  const [marketName, setMarketName] = useState(name);
+  const [marketTrueValue, setMarketTrueValue] = useState(0);
+  const [isDefaultTrueValue, setIsDefaultTrueValue] = useState(
+    trueValue !== -1
+  );
+  useEffect(() => {
+    setMarketName(name);
+  }, [name, markets]);
+  useEffect(() => {
+    setMarketTrueValue(trueValue);
+    setIsDefaultTrueValue(trueValue !== -1);
+  }, [trueValue]);
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <TextField
+          label="Market Name"
+          sx={{ width: '100%' }}
+          value={marketName}
+          onChange={(event) => {
+            setMarketName(event.target.value);
+            markets[selectedMarketIndex].name = event.target.value;
+            setMarkets([...markets]);
+          }}
+        />
+        <TextField
+          label="True Value"
+          type="number"
+          sx={{ minWidth: 25, ml: 2 }}
+          value={trueValue}
+          placeholder={`${marketTrueValue}`}
+          disabled={!isDefaultTrueValue}
+          onChange={(event) => {
+            setMarketTrueValue(event.target.value);
+            markets[selectedMarketIndex].trueValue = event.target.value;
+            setMarkets([...markets]);
+          }}
+        />
+        <Tooltip title="Default True Value">
+          <Switch
+            checked={isDefaultTrueValue}
+            onChange={() => {
+              // if true, set the opposite as we want it off.
+              markets[selectedMarketIndex].trueValue = isDefaultTrueValue
+                ? -1
+                : marketTrueValue;
+              setIsDefaultTrueValue((prev) => !prev);
+              setMarkets([...markets]);
+            }}
+          />
+        </Tooltip>
+        <Tooltip title="Delete Market">
+          <IconButton
+            color="error"
+            onClick={() => {
+              setSelectedMarketIndex(0);
+              setTimeout(() => {
+                markets.splice(selectedMarketIndex, 1);
+                setMarkets([...markets]);
+              }, 300);
+            }}
+            sx={{ p: 2, ml: 2 }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </Tooltip>
+      </Box>
+      {rounds?.map((round, index) => {
+        return (
+          <Box key={'roundBox' + index} sx={{ py: 2, pl: 4 }}>
+            <Typography key={'roundNum' + index}>Round {index + 1}</Typography>
+            <Box key={'roundDesc' + index} sx={{ display: 'flex', pt: 1 }}>
+              <TextField
+                key={'roundDescTextbox' + index}
+                label="Hint"
+                fullWidth
+                value={round?.hint}
+                placeholder={round?.hint}
+                onChange={(event) => {
+                  round.hint = event.target.value;
+                  setMarkets([...markets]);
+                }}
+              />
+              <Tooltip
+                title={
+                  <p>
+                    Delete round from <b>all markets</b>
+                  </p>
+                }
+              >
+                <IconButton
+                  color="error"
+                  onClick={() => {
+                    markets.forEach((market) => market.rounds.splice(index, 1));
+                    setMarkets([...markets]);
+                  }}
+                  sx={{ p: 2, ml: 2 }}
+                >
+                  <DeleteOutlineIcon />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          </Box>
+        );
+      })}
+      <Button
+        startIcon={<AddIcon />}
+        sx={{ ml: 4, mt: 2 }}
+        onClick={() => {
+          markets.forEach((market) => market.rounds.push({ ...ROUND_PAYLOAD }));
+          setMarkets([...markets]);
+        }}
+      >
+        New Round
+      </Button>
+    </Box>
+  );
+};
+export default EditGameMarket;

--- a/frontend/src/pages/EditGamePage/EditGameMarket.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameMarket.jsx
@@ -156,7 +156,8 @@ const EditGameMarket = ({
         sx={{ ml: 4, mt: 2 }}
         disabled={isDisabled}
         onClick={() => {
-          markets.forEach((market) => market.rounds.push({ ...ROUND_PAYLOAD }));
+          markets[selectedMarketIndex].rounds.push({ ...ROUND_PAYLOAD });
+          // markets.forEach((market) => market.rounds.push({ ...ROUND_PAYLOAD }));
           setMarkets([...markets]);
         }}
       >

--- a/frontend/src/pages/EditGamePage/EditGameMarket.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameMarket.jsx
@@ -25,6 +25,7 @@ const EditGameMarket = ({
   setSelectedMarketIndex,
   markets,
   setMarkets,
+  isDisabled,
 }) => {
   const [marketName, setMarketName] = useState(name);
   const [marketTrueValue, setMarketTrueValue] = useState(0);
@@ -52,6 +53,7 @@ const EditGameMarket = ({
           label="Market Name"
           sx={{ width: '100%' }}
           value={marketName}
+          disabled={isDisabled}
           onChange={(event) => {
             setMarketName(event.target.value);
             markets[selectedMarketIndex].name = event.target.value;
@@ -64,41 +66,47 @@ const EditGameMarket = ({
           sx={{ minWidth: 25, ml: 2 }}
           value={trueValue}
           placeholder={`${marketTrueValue}`}
-          disabled={!isDefaultTrueValue}
+          disabled={isDisabled || !isDefaultTrueValue}
           onChange={(event) => {
             setMarketTrueValue(event.target.value);
             markets[selectedMarketIndex].trueValue = event.target.value;
             setMarkets([...markets]);
           }}
         />
-        <Tooltip title="Default True Value">
-          <Switch
-            checked={isDefaultTrueValue}
-            onChange={() => {
-              // if true, set the opposite as we want it off.
-              markets[selectedMarketIndex].trueValue = isDefaultTrueValue
-                ? -1
-                : marketTrueValue;
-              setIsDefaultTrueValue((prev) => !prev);
-              setMarkets([...markets]);
-            }}
-          />
-        </Tooltip>
-        <Tooltip title="Delete Market">
-          <IconButton
-            color="error"
-            onClick={() => {
-              setSelectedMarketIndex(0);
-              setTimeout(() => {
-                markets.splice(selectedMarketIndex, 1);
+        {!isDisabled && (
+          <Tooltip title="Default True Value">
+            <Switch
+              checked={isDefaultTrueValue}
+              disabled={isDisabled}
+              onChange={() => {
+                // if true, set the opposite as we want it off.
+                markets[selectedMarketIndex].trueValue = isDefaultTrueValue
+                  ? -1
+                  : marketTrueValue;
+                setIsDefaultTrueValue((prev) => !prev);
                 setMarkets([...markets]);
-              }, 300);
-            }}
-            sx={{ p: 2, ml: 2, opacity: 0.7 }}
-          >
-            <CloseIcon />
-          </IconButton>
-        </Tooltip>
+              }}
+            />
+          </Tooltip>
+        )}
+        {!isDisabled && (
+          <Tooltip title="Delete Market">
+            <IconButton
+              color="error"
+              disabled={isDisabled}
+              onClick={() => {
+                setSelectedMarketIndex(0);
+                setTimeout(() => {
+                  markets.splice(selectedMarketIndex, 1);
+                  setMarkets([...markets]);
+                }, 300);
+              }}
+              sx={{ p: 2, ml: 2, opacity: 0.7 }}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Tooltip>
+        )}
       </Box>
       {rounds?.map((round, index) => {
         return (
@@ -111,29 +119,34 @@ const EditGameMarket = ({
                 fullWidth
                 value={round?.hint}
                 placeholder={round?.hint}
+                disabled={isDisabled}
                 onChange={(event) => {
                   round.hint = event.target.value;
                   setMarkets([...markets]);
                 }}
               />
-              <Tooltip
-                title={
-                  <p>
-                    Delete round from <b>all markets</b>
-                  </p>
-                }
-              >
-                <IconButton
-                  color="error"
-                  onClick={() => {
-                    markets.forEach((market) => market.rounds.splice(index, 1));
-                    setMarkets([...markets]);
-                  }}
-                  sx={{ p: 2, ml: 2, opacity: 0.7 }}
+              {!isDisabled && (
+                <Tooltip
+                  title={
+                    <p>
+                      Delete round from <b>all markets</b>
+                    </p>
+                  }
                 >
-                  <DeleteOutlineIcon />
-                </IconButton>
-              </Tooltip>
+                  <IconButton
+                    color="error"
+                    onClick={() => {
+                      markets.forEach((market) =>
+                        market.rounds.splice(index, 1)
+                      );
+                      setMarkets([...markets]);
+                    }}
+                    sx={{ p: 2, ml: 2, opacity: 0.7 }}
+                  >
+                    <DeleteOutlineIcon />
+                  </IconButton>
+                </Tooltip>
+              )}
             </Box>
           </Box>
         );
@@ -141,6 +154,7 @@ const EditGameMarket = ({
       <Button
         startIcon={<AddIcon />}
         sx={{ ml: 4, mt: 2 }}
+        disabled={isDisabled}
         onClick={() => {
           markets.forEach((market) => market.rounds.push({ ...ROUND_PAYLOAD }));
           setMarkets([...markets]);

--- a/frontend/src/pages/EditGamePage/EditGameMarket.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameMarket.jsx
@@ -156,8 +156,8 @@ const EditGameMarket = ({
         sx={{ ml: 4, mt: 2 }}
         disabled={isDisabled}
         onClick={() => {
-          markets[selectedMarketIndex].rounds.push({ ...ROUND_PAYLOAD });
-          // markets.forEach((market) => market.rounds.push({ ...ROUND_PAYLOAD }));
+          // markets[selectedMarketIndex].rounds.push({ ...ROUND_PAYLOAD });
+          markets.forEach((market) => market.rounds.push({ ...ROUND_PAYLOAD }));
           setMarkets([...markets]);
         }}
       >

--- a/frontend/src/pages/EditGamePage/EditGamePage.jsx
+++ b/frontend/src/pages/EditGamePage/EditGamePage.jsx
@@ -9,18 +9,12 @@ import {
   Divider,
   TextField,
   Typography,
-  IconButton,
-  Tooltip,
   Skeleton,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import SaveIcon from '@mui/icons-material/Save';
-import AddIcon from '@mui/icons-material/Add';
 import SegmentIcon from '@mui/icons-material/Segment';
 import DoneIcon from '@mui/icons-material/Done';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import CloseIcon from '@mui/icons-material/Close';
-import EditGameMarket from './EditGameMarket';
 import EditGameSection from './EditGameSection';
 
 const EditGamePage = () => {
@@ -42,7 +36,6 @@ const EditGamePage = () => {
       setOldGameDesc(gameData.desc);
       setGameDesc(gameData.desc);
       setGameSections(gameData.sections);
-      // setGameRounds(gameData.sections);
       setIsLoading(false);
     };
     fetchGame();

--- a/frontend/src/pages/EditGamePage/EditGamePage.jsx
+++ b/frontend/src/pages/EditGamePage/EditGamePage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { fetchAPIRequest } from '../helpers';
-import { ImageUploadBtn } from '../components/index.js';
+import { fetchAPIRequest } from '../../helpers';
+import { ImageUploadBtn } from '../../components/index.js';
 
 import {
   Box,
@@ -16,10 +16,12 @@ import {
 import EditIcon from '@mui/icons-material/Edit';
 import SaveIcon from '@mui/icons-material/Save';
 import AddIcon from '@mui/icons-material/Add';
-import ShowChartIcon from '@mui/icons-material/ShowChart';
+import SegmentIcon from '@mui/icons-material/Segment';
 import DoneIcon from '@mui/icons-material/Done';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import CloseIcon from '@mui/icons-material/Close';
+import EditGameMarket from './EditGameMarket';
+import EditGameSection from './EditGameSection';
 
 const EditGamePage = () => {
   const { gameId } = useParams();
@@ -27,7 +29,7 @@ const EditGamePage = () => {
   const [gameName, setGameName] = useState('Loading...');
   const [oldGameDesc, setOldGameDesc] = useState('Loading...');
   const [gameDesc, setGameDesc] = useState('Loading...');
-  const [gameRounds, setGameRounds] = useState([]);
+  const [gameSections, setGameSections] = useState([]);
   const [gameMedia, setGameMedia] = useState(null);
   const [isSaved, setIsSaved] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -39,144 +41,51 @@ const EditGamePage = () => {
       setGameName(gameData.name);
       setOldGameDesc(gameData.desc);
       setGameDesc(gameData.desc);
-      setGameRounds(gameData.markets);
+      setGameSections(gameData.sections);
+      // setGameRounds(gameData.sections);
       setIsLoading(false);
     };
     fetchGame();
   }, [gameId]);
 
+  useEffect(() => {
+    setIsSaved(false);
+  }, [gameName, gameDesc, gameMedia, gameSections, setIsSaved]);
+
   const saveChanges = async () => {
     await fetchAPIRequest(`/games/${gameId}`, 'PUT', {
-      markets: gameRounds,
+      sections: gameSections,
       name: gameName,
       desc: gameDesc,
       media: gameMedia,
     });
   };
 
-  const renderMarketRounds = (markets) => {
+  const renderMarketRounds = (sections) => {
     return (
       <Box>
-        {markets.map((market, marketIndex) => {
-          return (
-            <Box
-              key={'market' + marketIndex}
-              sx={{
-                px: 2,
-                pt: 3,
-                pb: 2,
-                mb: 3,
-                border: '1px solid lightgray',
-                borderRadius: 3,
-              }}
-            >
-              <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <TextField
-                  key={'marketNameTextbox' + marketIndex}
-                  label="Market Name"
-                  sx={{ width: '100%' }}
-                  defaultValue={market.name}
-                  placeholder={market.name}
-                  onChange={(event) => {
-                    markets[marketIndex].name = event.target.value;
-                    setGameRounds([...markets]);
-                    setIsSaved(false);
-                  }}
-                />
-                <TextField
-                  key={'marketTrueValue' + marketIndex}
-                  label="True Value"
-                  type="number"
-                  sx={{ minWidth: 25, ml: 2 }}
-                  value={markets[marketIndex].trueValue}
-                  placeholder={`${market.trueValue}`}
-                  onChange={(event) => {
-                    markets[marketIndex].trueValue = event.target.value;
-                    setGameRounds([...markets]);
-                    setIsSaved(false);
-                  }}
-                />
-                <Tooltip title="Delete Market">
-                  <IconButton
-                    color="error"
-                    onClick={() => {
-                      markets.splice(marketIndex, 1);
-                      setGameRounds([...markets]);
-                      setIsSaved(false);
-                    }}
-                    sx={{ p: 2, ml: 2 }}
-                  >
-                    <CloseIcon />
-                  </IconButton>
-                </Tooltip>
-              </Box>
-              {market.rounds.map((round, index) => {
-                return (
-                  <Box key={'roundBox' + index} sx={{ py: 2, pl: 4 }}>
-                    <Typography key={'roundNum' + index}>
-                      Round {index + 1}
-                    </Typography>
-                    <Box
-                      key={'roundDesc' + index}
-                      sx={{ display: 'flex', pt: 1 }}
-                    >
-                      <TextField
-                        key={'roundDescTextbox' + index}
-                        label="Hint"
-                        fullWidth
-                        value={markets[marketIndex].rounds[index].hint}
-                        placeholder={markets[marketIndex].rounds[index].hint}
-                        onChange={(event) => {
-                          markets[marketIndex].rounds[index].hint =
-                            event.target.value;
-                          setGameRounds([...markets]);
-                          setIsSaved(false);
-                        }}
-                      />
-                      <IconButton
-                        color="error"
-                        onClick={() => {
-                          markets[marketIndex].rounds.splice(index, 1);
-                          setGameRounds([...markets]);
-                          setIsSaved(false);
-                        }}
-                        sx={{ p: 2, ml: 2 }}
-                      >
-                        <DeleteOutlineIcon />
-                      </IconButton>
-                    </Box>
-                  </Box>
-                );
-              })}
-              <Button
-                key={'marketAddRound' + marketIndex}
-                startIcon={<AddIcon />}
-                sx={{ ml: 4 }}
-                onClick={() => {
-                  markets[marketIndex].rounds.push({ hint: '' });
-                  setGameRounds([...markets]);
-                  setIsSaved(false);
-                }}
-              >
-                New Round
-              </Button>
-            </Box>
-          );
-        })}
+        {/* <Button onClick={() => console.log(gameSections)}>CLICK ME</Button> */}
+        {sections.map((section, index) => (
+          <EditGameSection
+            key={index}
+            section={section}
+            setIsSaved={setIsSaved}
+            setGameSections={setGameSections}
+            index={index}
+          />
+        ))}
         <Button
-          startIcon={<ShowChartIcon />}
-          // sx={{}}
+          startIcon={<SegmentIcon />}
           onClick={() => {
-            markets.push({
+            sections.push({
               name: '',
-              trueValue: 0,
-              rounds: [],
+              markets: [],
             });
-            setGameRounds([...markets]);
+            setGameSections([...sections]);
             setIsSaved(false);
           }}
         >
-          New Market
+          New Section
         </Button>
       </Box>
     );
@@ -253,7 +162,7 @@ const EditGamePage = () => {
           />
           <Divider sx={{ my: 4 }} />
           <Typography variant="h5" sx={{ pb: 2 }}>
-            Markets
+            Game Sections
           </Typography>
           {isLoading && (
             <>
@@ -264,7 +173,7 @@ const EditGamePage = () => {
               <Skeleton width="100%" height={100} />
             </>
           )}
-          {renderMarketRounds(gameRounds)}
+          {renderMarketRounds(gameSections)}
           {/* <Button></Button> */}
         </Box>
         <Box

--- a/frontend/src/pages/EditGamePage/EditGameSection.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameSection.jsx
@@ -5,10 +5,19 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditGameTabs from './EditGameTabs';
 import EditGameMarket from './EditGameMarket';
 
-const EditGameSection = ({ section, setGameSections, setIsSaved, index }) => {
+const EditGameSection = ({
+  section,
+  index,
+  setGameSections,
+  setIsSaved,
+  isDisabled,
+}) => {
   const [selectedMarketIndex, setSelectedMarketIndex] = useState(0);
   const [markets, setMarkets] = useState(section.markets);
   useEffect(() => {
+    if (isDisabled) {
+      return () => {};
+    }
     setIsSaved(false);
     // save section changes
     setGameSections((sections) => {
@@ -19,7 +28,7 @@ const EditGameSection = ({ section, setGameSections, setIsSaved, index }) => {
         return section;
       });
     });
-  }, [markets, setIsSaved, setGameSections, index]);
+  }, [markets, setIsSaved, setGameSections, index, isDisabled]);
 
   return (
     <Box
@@ -41,19 +50,22 @@ const EditGameSection = ({ section, setGameSections, setIsSaved, index }) => {
         }}
       >
         <Typography variant="h6">Section {index + 1}</Typography>
-        <Button
-          color="error"
-          size="small"
-          onClick={() => {
-            setGameSections((sections) => {
-              sections.splice(index, 1);
-              return [...sections];
-            });
-          }}
-          sx={{ py: 1, opacity: 0.7 }}
-        >
-          Delete Section
-        </Button>
+        {!isDisabled && (
+          <Button
+            color="error"
+            size="small"
+            onClick={() => {
+              setGameSections((sections) => {
+                sections.splice(index, 1);
+                return [...sections];
+              });
+            }}
+            disabled={isDisabled}
+            sx={{ py: 1, opacity: 0.7 }}
+          >
+            Delete Section
+          </Button>
+        )}
       </Box>
       <Box
         sx={{
@@ -68,26 +80,29 @@ const EditGameSection = ({ section, setGameSections, setIsSaved, index }) => {
           selectedMarketIndex={selectedMarketIndex}
           setSelectedMarketIndex={setSelectedMarketIndex}
         />
-        <Button
-          startIcon={<ShowChartIcon />}
-          onClick={() => {
-            let newRounds = [];
-            let globalRoundsLength = markets.slice(-1)[0]?.rounds.length;
-            if (markets.length > 0 && globalRoundsLength > 0) {
-              newRounds = Array.from({ length: globalRoundsLength }, () => {
-                return { hint: '' };
+        {!isDisabled && (
+          <Button
+            startIcon={<ShowChartIcon />}
+            disabled={isDisabled}
+            onClick={() => {
+              let newRounds = [];
+              let globalRoundsLength = markets.slice(-1)[0]?.rounds.length;
+              if (markets.length > 0 && globalRoundsLength > 0) {
+                newRounds = Array.from({ length: globalRoundsLength }, () => {
+                  return { hint: '' };
+                });
+              }
+              markets.push({
+                name: `New Market ${markets.length + 1}`,
+                trueValue: 0,
+                rounds: newRounds,
               });
-            }
-            markets.push({
-              name: `New Market ${markets.length + 1}`,
-              trueValue: 0,
-              rounds: newRounds,
-            });
-            setMarkets([...markets]);
-          }}
-        >
-          New Market
-        </Button>
+              setMarkets([...markets]);
+            }}
+          >
+            New Market
+          </Button>
+        )}
       </Box>
 
       {markets.length > 0 && (
@@ -99,6 +114,7 @@ const EditGameSection = ({ section, setGameSections, setIsSaved, index }) => {
           setSelectedMarketIndex={setSelectedMarketIndex}
           markets={markets}
           setMarkets={setMarkets}
+          isDisabled={isDisabled}
         />
       )}
     </Box>

--- a/frontend/src/pages/EditGamePage/EditGameSection.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameSection.jsx
@@ -4,6 +4,10 @@ import ShowChartIcon from '@mui/icons-material/ShowChart';
 import EditGameTabs from './EditGameTabs';
 import EditGameMarket from './EditGameMarket';
 
+const MARKET_PAYLOAD = {
+  rounds: [],
+};
+
 const EditGameSection = ({
   section,
   index,
@@ -84,18 +88,22 @@ const EditGameSection = ({
             startIcon={<ShowChartIcon />}
             disabled={isDisabled}
             onClick={() => {
-              let newRounds = [];
-              let globalRoundsLength = markets.slice(-1)[0]?.rounds.length;
-              if (markets.length > 0 && globalRoundsLength > 0) {
-                newRounds = Array.from({ length: globalRoundsLength }, () => {
-                  return { hint: '' };
-                });
-              }
-              markets.push({
-                name: `New Market ${markets.length + 1}`,
-                trueValue: 0,
-                rounds: newRounds,
-              });
+              // let newRounds = [];
+              // let globalRoundsLength = markets.slice(-1)[0]?.rounds.length;
+              // if (markets.length > 0 && globalRoundsLength > 0) {
+              //   newRounds = Array.from({ length: globalRoundsLength }, () => {
+              //     return { hint: '' };
+              //   });
+              // }
+              // markets.push({
+              //   name: `New Market ${markets.length + 1}`,
+              //   trueValue: 0,
+              //   rounds: newRounds,
+              // });
+              const newMarket = { ...MARKET_PAYLOAD };
+              newMarket.name = `New Market ${markets.length + 1}`;
+              newMarket.trueValue = 0;
+              markets.push(newMarket);
               setMarkets([...markets]);
             }}
           >

--- a/frontend/src/pages/EditGamePage/EditGameSection.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameSection.jsx
@@ -1,0 +1,107 @@
+import { useState, useEffect } from 'react';
+import { Box, Button, IconButton, Typography } from '@mui/material';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditGameTabs from './EditGameTabs';
+import EditGameMarket from './EditGameMarket';
+
+const EditGameSection = ({ section, setGameSections, setIsSaved, index }) => {
+  const [selectedMarketIndex, setSelectedMarketIndex] = useState(0);
+  const [markets, setMarkets] = useState(section.markets);
+  useEffect(() => {
+    setIsSaved(false);
+    // save section changes
+    setGameSections((sections) => {
+      return sections.map((section, sIndex) => {
+        if (sIndex === index) {
+          section.markets = markets;
+        }
+        return section;
+      });
+    });
+  }, [markets, setIsSaved, setGameSections, index]);
+
+  return (
+    <Box
+      sx={{
+        px: 2,
+        pt: 2,
+        pb: 2,
+        mb: 3,
+        border: '1px solid lightgray',
+        borderRadius: 3,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+        }}
+      >
+        <Typography variant="h6">Section {index + 1}</Typography>
+        <Button
+          color="error"
+          size="small"
+          onClick={() => {
+            setGameSections((sections) => {
+              sections.splice(index, 1);
+              return [...sections];
+            });
+          }}
+          sx={{ py: 1 }}
+        >
+          Delete Section
+        </Button>
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'start',
+          my: 1,
+        }}
+      >
+        <EditGameTabs
+          markets={markets}
+          selectedMarketIndex={selectedMarketIndex}
+          setSelectedMarketIndex={setSelectedMarketIndex}
+        />
+        <Button
+          startIcon={<ShowChartIcon />}
+          onClick={() => {
+            let newRounds = [];
+            let globalRoundsLength = markets.slice(-1)[0]?.rounds.length;
+            if (markets.length > 0 && globalRoundsLength > 0) {
+              newRounds = Array.from({ length: globalRoundsLength }, () => {
+                return { hint: '' };
+              });
+            }
+            markets.push({
+              name: `New Market ${markets.length + 1}`,
+              trueValue: 0,
+              rounds: newRounds,
+            });
+            setMarkets([...markets]);
+          }}
+        >
+          New Market
+        </Button>
+      </Box>
+
+      {markets.length > 0 && (
+        <EditGameMarket
+          name={markets[selectedMarketIndex].name}
+          rounds={markets[selectedMarketIndex].rounds}
+          trueValue={markets[selectedMarketIndex]?.trueValue}
+          selectedMarketIndex={selectedMarketIndex}
+          setSelectedMarketIndex={setSelectedMarketIndex}
+          markets={markets}
+          setMarkets={setMarkets}
+        />
+      )}
+    </Box>
+  );
+};
+export default EditGameSection;

--- a/frontend/src/pages/EditGamePage/EditGameSection.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameSection.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
-import { Box, Button, IconButton, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditGameTabs from './EditGameTabs';
 import EditGameMarket from './EditGameMarket';
 

--- a/frontend/src/pages/EditGamePage/EditGameSection.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameSection.jsx
@@ -4,7 +4,8 @@ import ShowChartIcon from '@mui/icons-material/ShowChart';
 import EditGameTabs from './EditGameTabs';
 import EditGameMarket from './EditGameMarket';
 
-const MARKET_PAYLOAD = {
+// all markets will use the same rounds array.
+let marketPayload = {
   rounds: [],
 };
 
@@ -105,7 +106,16 @@ const EditGameSection = ({
               //   trueValue: 0,
               //   rounds: newRounds,
               // });
-              const newMarket = { ...MARKET_PAYLOAD };
+
+              // overwrite single rounds array object with new one as the old
+              // one still has data stored.
+              if (markets.length <= 0) {
+                marketPayload = { rounds: [] };
+              } else {
+                marketPayload = { rounds: markets[0].rounds };
+              }
+
+              const newMarket = { ...marketPayload };
               newMarket.name = `New Market ${markets.length + 1}`;
               newMarket.trueValue = 0;
               markets.push(newMarket);
@@ -120,7 +130,7 @@ const EditGameSection = ({
       {markets.length > 0 && (
         <EditGameMarket
           name={markets[selectedMarketIndex].name}
-          rounds={markets[selectedMarketIndex].rounds}
+          rounds={markets[0].rounds}
           trueValue={markets[selectedMarketIndex]?.trueValue}
           selectedMarketIndex={selectedMarketIndex}
           setSelectedMarketIndex={setSelectedMarketIndex}

--- a/frontend/src/pages/EditGamePage/EditGameSection.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameSection.jsx
@@ -50,7 +50,7 @@ const EditGameSection = ({ section, setGameSections, setIsSaved, index }) => {
               return [...sections];
             });
           }}
-          sx={{ py: 1 }}
+          sx={{ py: 1, opacity: 0.7 }}
         >
           Delete Section
         </Button>

--- a/frontend/src/pages/EditGamePage/EditGameSection.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameSection.jsx
@@ -74,7 +74,7 @@ const EditGameSection = ({
         sx={{
           display: 'flex',
           justifyContent: 'space-between',
-          alignItems: 'start',
+          alignItems: 'flex-start',
           my: 1,
         }}
       >
@@ -83,6 +83,11 @@ const EditGameSection = ({
           selectedMarketIndex={selectedMarketIndex}
           setSelectedMarketIndex={setSelectedMarketIndex}
         />
+        {markets.length <= 0 && (
+          <Typography color="text.secondary" sx={{ my: 'auto' }}>
+            No markets. Start by creating one!
+          </Typography>
+        )}
         {!isDisabled && (
           <Button
             startIcon={<ShowChartIcon />}

--- a/frontend/src/pages/EditGamePage/EditGameTabs.jsx
+++ b/frontend/src/pages/EditGamePage/EditGameTabs.jsx
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import { Box, Tabs, Tab } from '@mui/material';
+
+const EditGameTabs = ({
+  markets,
+  selectedMarketIndex,
+  setSelectedMarketIndex,
+}) => {
+  const [value, setValue] = useState(
+    selectedMarketIndex < markets.length ? selectedMarketIndex : 0
+  );
+  useEffect(() => {
+    setValue(selectedMarketIndex < markets.length ? selectedMarketIndex : 0);
+  }, [selectedMarketIndex, setValue, markets]);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+    setSelectedMarketIndex(newValue);
+  };
+
+  return (
+    markets.length > 0 && (
+      <Box sx={{ mb: 3 }}>
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          textColor="primary"
+          indicatorColor="secondary"
+          aria-label="game section tabs"
+        >
+          {markets.map((market, index) => (
+            <Tab key={market.name + index} value={index} label={market.name} />
+          ))}
+        </Tabs>
+      </Box>
+    )
+  );
+};
+export default EditGameTabs;

--- a/frontend/src/pages/EditGamePage/index.js
+++ b/frontend/src/pages/EditGamePage/index.js
@@ -1,0 +1,4 @@
+export { default as EditGamePage } from './EditGamePage.jsx';
+export { default as EditGameMarket } from './EditGameMarket.jsx';
+export { default as EditGameSection } from './EditGameSection.jsx';
+export { default as EditGameTabs } from './EditGameTabs.jsx';

--- a/frontend/src/pages/GameHistoryPage/TeamStats.jsx
+++ b/frontend/src/pages/GameHistoryPage/TeamStats.jsx
@@ -24,6 +24,7 @@ const TeamStats = ({
         p: 2,
         border: '0.5px solid',
         borderColor: isWinner ? 'limegreen' : '#E0E0E0',
+        minWidth: 260,
       }}
     >
       <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -71,7 +72,7 @@ const TeamStats = ({
         <Box sx={{ display: 'flex', justifyContent: 'space-around' }}>
           <Typography
             color={bid && 'error'}
-            sx={{ display: 'flex', alignItems: 'center' }}
+            sx={{ display: 'flex', alignItems: 'center', textWrap: 'nowrap' }}
           >
             <ArrowDropDownOutlinedIcon color="error" fontSize="large" />
             Bid {bid ? bid.toFixed(2) : '--'}
@@ -81,6 +82,7 @@ const TeamStats = ({
               display: 'flex',
               alignItems: 'center',
               color: ask && '#2e7d32',
+              textWrap: 'nowrap',
             }}
           >
             <ArrowDropUpOutlinedIcon color="success" fontSize="large" />

--- a/frontend/src/pages/PlayGamePage.jsx
+++ b/frontend/src/pages/PlayGamePage.jsx
@@ -101,9 +101,10 @@ const PlayGamePage = () => {
       }
       setIsLoading(false);
     };
-    setInterval(() => {
+    const gameInterval = setInterval(() => {
       getGameStatus();
     }, 1000);
+    return () => clearInterval(gameInterval);
   }, [sessionId, alertCtx]);
 
   return (

--- a/frontend/src/pages/PlayGamePage/PlayGameMarketSelector.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGameMarketSelector.jsx
@@ -1,0 +1,27 @@
+import { Box, InputLabel, Select, FormControl, MenuItem } from '@mui/material';
+
+const PlayGameMarketSelector = ({ current, setSelectedMarketIndex }) => {
+  return (
+    <Box sx={{ maxWidth: 500, mt: 5, mb: 3, mx: 'auto' }}>
+      <FormControl fullWidth>
+        <InputLabel htmlFor="uncontrolled-select">Market</InputLabel>
+        <Select
+          defaultValue={0}
+          label="Market"
+          id="uncontrolled-select"
+          onChange={(event) => {
+            setSelectedMarketIndex(event.target.value);
+          }}
+        >
+          {current?.round &&
+            Object.keys(current.round).map((market, index) => (
+              <MenuItem key={index} value={index}>
+                {market}
+              </MenuItem>
+            ))}
+        </Select>
+      </FormControl>
+    </Box>
+  );
+};
+export default PlayGameMarketSelector;

--- a/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
@@ -262,7 +262,9 @@ const PlayGamePage = () => {
                   <Divider sx={{ my: 3 }} />
                   <Typography variant="h6">
                     {question.type === 'result' &&
-                      `The fair value of this market is $${question.trueValue}.`}
+                      `The fair value of this market is $${
+                        Object.values(question.round)[selectedMarketIndex]
+                      }.`}
                   </Typography>
                   <Typography fontSize={18}>
                     {question.type === 'round' &&

--- a/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
@@ -19,20 +19,19 @@ import { AlertContext } from '../../contexts/NotificationContext';
 import PlayGameTradeArea from './PlayGameTradeArea';
 import { GameTransition } from '../../components';
 
-const getTeamCookie = () => {
+const getTeamCookie = (sessionId) => {
   return document.cookie
     ?.split(';')
-    ?.filter((item) => item.includes('localTeamId'))[0]
+    ?.filter((item) => item.includes(sessionId))[0]
     ?.split('=')[1];
 };
 
-const setTeamCookie = (newTeamId) => {
-  document.cookie = `localTeamId=${newTeamId}`;
+const setTeamCookie = (sessionId, newTeamId) => {
+  document.cookie = `${sessionId}=${newTeamId}`;
 };
 
-const deleteTeamCookie = () => {
-  document.cookie =
-    'localTeamId=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+const deleteTeamCookie = (sessionId) => {
+  document.cookie = `${sessionId}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 };
 
 const PlayGamePage = () => {
@@ -45,7 +44,7 @@ const PlayGamePage = () => {
   const [teams, setTeams] = useState({});
   const [isLoading, setIsLoading] = useState(true);
   const [isTeamCreated, setIsTeamCreated] = useState(
-    getTeamCookie() ? true : false
+    getTeamCookie(sessionId) ? true : false
   );
   const alertCtx = useContext(AlertContext);
   const [quotable, setQuotable] = useState('');
@@ -63,7 +62,7 @@ const PlayGamePage = () => {
       name: teamName,
     });
     setMyTeamId(teamData.teamId);
-    setTeamCookie(teamData.teamId);
+    setTeamCookie(sessionId, teamData.teamId);
     setIsTeamCreated(true);
   };
 
@@ -104,10 +103,10 @@ const PlayGamePage = () => {
   };
 
   useEffect(() => {
-    if (getTeamCookie()) {
-      setMyTeamId(getTeamCookie());
+    if (getTeamCookie(sessionId)) {
+      setMyTeamId(getTeamCookie(sessionId));
     }
-  }, []);
+  }, [sessionId]);
 
   useEffect(() => {
     const getGameStatus = async () => {
@@ -126,7 +125,7 @@ const PlayGamePage = () => {
       setQuestion(status.questions);
       setTeams(status.teams);
       if (!status.active) {
-        deleteTeamCookie();
+        deleteTeamCookie(sessionId);
         alertCtx.info('This session has finished!');
       }
       setIsLoading(false);

--- a/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
@@ -14,11 +14,9 @@ import {
   FormControl,
 } from '@mui/material';
 import PriceChangeIcon from '@mui/icons-material/PriceChange';
-import { BidAskPanel } from '../../components/index.js';
 import TeamStats from '../GameHistoryPage/TeamStats';
 import { AlertContext } from '../../contexts/NotificationContext';
 import PlayGameTradeArea from './PlayGameTradeArea';
-import PlayGameMarketSelector from './PlayGameMarketSelector';
 
 const PlayGamePage = () => {
   const { sessionId } = useParams();
@@ -28,7 +26,6 @@ const PlayGamePage = () => {
   const [position, setPosition] = useState(-1);
   const [question, setQuestion] = useState({});
   const [teams, setTeams] = useState({});
-  const [marketPosition, setMarketPosition] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isTeamCreated, setIsTeamCreated] = useState(
     localStorage.getItem('localTeamId') ? true : false
@@ -54,16 +51,14 @@ const PlayGamePage = () => {
       });
   }, [position]);
 
-  const processResults = (teams) => {
+  const processResults = (teams, marketIndex) => {
     const teamResults = Object.keys(teams)
       .map((teamId, index) => {
-        const trueValue = Object.values(question.round)[selectedMarketIndex];
+        const trueValue = Object.values(question.round)[marketIndex];
         const balance =
-          teams[teamId].teamAnswers[position].markets[selectedMarketIndex]
-            .balance;
+          teams[teamId].teamAnswers[position].markets[marketIndex].balance;
         const contracts =
-          teams[teamId].teamAnswers[position].markets[selectedMarketIndex]
-            .contracts;
+          teams[teamId].teamAnswers[position].markets[marketIndex].contracts;
         const total =
           parseInt(contracts, 10) * parseFloat(trueValue, 10) +
           parseFloat(balance, 10);
@@ -99,9 +94,6 @@ const PlayGamePage = () => {
       setPosition(status.position);
       setQuestion(status.questions);
       setTeams(status.teams);
-      if (status.position >= 0 && status.questions.type === 'market') {
-        setMarketPosition(status.position);
-      }
       if (!status.active) {
         localStorage.removeItem('localTeamId');
         alertCtx.info('This session has finished!');
@@ -134,7 +126,7 @@ const PlayGamePage = () => {
           borderRadius: '10px 10px 0px 0px',
           boxShadow: 2,
           width: '100%',
-          px: { xs: 2, sm: 5 },
+          px: { xs: 2, sm: 3, lg: 5 },
           py: 7,
         }}
       >
@@ -223,7 +215,7 @@ const PlayGamePage = () => {
                 Session already started...
               </Typography>
             ) : (
-              <>
+              <Box sx={{ m: 0, p: 0 }}>
                 <Box
                   sx={{
                     boxShadow: 2,
@@ -260,12 +252,12 @@ const PlayGamePage = () => {
                     </Typography>
                   )}
                   <Divider sx={{ my: 3 }} />
-                  <Typography variant="h6">
+                  {/* <Typography variant="h6">
                     {question.type === 'result' &&
                       `The fair value of this market is $${
                         Object.values(question.round)[selectedMarketIndex]
                       }.`}
-                  </Typography>
+                  </Typography> */}
                   <Typography fontSize={18}>
                     {question.type === 'round' &&
                       'Trading is in session. Please wait for the trades to complete.'}
@@ -280,7 +272,7 @@ const PlayGamePage = () => {
                     {quotable.content} <br /> - {quotable.author}
                   </Typography>
                 </Box>
-                {question.type !== 'section' && (
+                {/* {question.type !== 'section' && (
                   <PlayGameMarketSelector
                     current={question}
                     setSelectedMarketIndex={setSelectedMarketIndex}
@@ -294,34 +286,118 @@ const PlayGamePage = () => {
                     myTeamId={myTeamId}
                     selectedMarketIndex={selectedMarketIndex}
                   />
-                )}
-                <Grid container columns={12} spacing={3} sx={{ py: 3 }}>
-                  {question.type === 'result' &&
-                    processResults(teams).map((team, index) => {
+                )} */}
+
+                <Grid
+                  container
+                  columns={24}
+                  // columnSpacing={{ xs: 1, sm: 2, md: 3 }}
+                  sx={{ mt: 4 }}
+                >
+                  {question?.type === 'round' &&
+                    Object.keys(question.round).map((market, index) => {
                       return (
                         <Grid
                           item
-                          xs={12}
-                          md={6}
-                          lg={4}
+                          xs={24}
+                          md={24}
+                          lg={12}
+                          xl={12}
                           key={index}
-                          sx={{ display: 'flex', justifyContent: 'center' }}
+                          sx={{
+                            // border: '0.5px solid #41414111',
+                            borderRadius: '10px',
+                            mb: 7,
+                          }}
                         >
-                          <FormControl sx={{ width: '100%' }}>
-                            <TeamStats
-                              key={team.teamId}
-                              teamName={team.teamName}
-                              balance={team.balance}
-                              contracts={team.contracts}
-                              trueValue={team.trueValue}
-                              isWinner={team.isWinner}
-                            />
-                          </FormControl>
+                          <Typography
+                            sx={{ mb: 1, fontSize: 18, textAlign: 'center' }}
+                          >
+                            {market}
+                          </Typography>
+                          <PlayGameTradeArea
+                            current={question}
+                            position={position}
+                            teams={teams}
+                            myTeamId={myTeamId}
+                            selectedMarketIndex={index}
+                          />
                         </Grid>
                       );
                     })}
                 </Grid>
-              </>
+                <Grid
+                  container
+                  columns={24}
+                  columnSpacing={{ xs: 1, sm: 2, md: 3 }}
+                  sx={{ mt: 4 }}
+                >
+                  {question?.type === 'result' &&
+                    Object.keys(question.round).map((market, marketIndex) => {
+                      return (
+                        <Grid
+                          item
+                          xs={24}
+                          md={24}
+                          lg={12}
+                          xl={12}
+                          key={marketIndex}
+                          sx={{
+                            // border: '0.5px solid #41414111',
+                            borderRadius: '10px',
+                            mb: 7,
+                          }}
+                        >
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              alignItems: 'flex-end',
+                              mb: 1,
+                            }}
+                          >
+                            <Typography fontSize={18}>{market}</Typography>
+                            <Typography color="text.secondary" sx={{ mr: 2 }}>
+                              True Value $
+                              {Object.values(question.round)[marketIndex]}
+                            </Typography>
+                          </Box>
+                          <Grid container columns={12} spacing={1}>
+                            {processResults(teams, marketIndex).map(
+                              (team, index) => {
+                                return (
+                                  <Grid
+                                    item
+                                    xs={12}
+                                    sm={6}
+                                    md={6}
+                                    lg={6}
+                                    key={index}
+                                    sx={{
+                                      display: 'flex',
+                                      justifyContent: 'center',
+                                    }}
+                                  >
+                                    <FormControl sx={{ width: '100%' }}>
+                                      <TeamStats
+                                        key={`team-stats-${index}`}
+                                        teamName={team.teamName}
+                                        balance={team.balance}
+                                        contracts={team.contracts}
+                                        isWinner={team.isWinner}
+                                        trueValue={team.trueValue}
+                                      />
+                                    </FormControl>
+                                  </Grid>
+                                );
+                              }
+                            )}
+                          </Grid>
+                        </Grid>
+                      );
+                    })}
+                </Grid>
+              </Box>
             ))}
         </Box>
       </Box>

--- a/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
@@ -19,6 +19,22 @@ import { AlertContext } from '../../contexts/NotificationContext';
 import PlayGameTradeArea from './PlayGameTradeArea';
 import { GameTransition } from '../../components';
 
+const getTeamCookie = () => {
+  return document.cookie
+    ?.split(';')
+    ?.filter((item) => item.includes('localTeamId'))[0]
+    ?.split('=')[1];
+};
+
+const setTeamCookie = (newTeamId) => {
+  document.cookie = `localTeamId=${newTeamId}`;
+};
+
+const deleteTeamCookie = () => {
+  document.cookie =
+    'localTeamId=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+};
+
 const PlayGamePage = () => {
   const { sessionId } = useParams();
   const [teamName, setTeamName] = useState('');
@@ -29,7 +45,7 @@ const PlayGamePage = () => {
   const [teams, setTeams] = useState({});
   const [isLoading, setIsLoading] = useState(true);
   const [isTeamCreated, setIsTeamCreated] = useState(
-    localStorage.getItem('localTeamId') ? true : false
+    getTeamCookie() ? true : false
   );
   const alertCtx = useContext(AlertContext);
   const [quotable, setQuotable] = useState('');
@@ -47,7 +63,7 @@ const PlayGamePage = () => {
       name: teamName,
     });
     setMyTeamId(teamData.teamId);
-    localStorage.setItem('localTeamId', teamData.teamId);
+    setTeamCookie(teamData.teamId);
     setIsTeamCreated(true);
   };
 
@@ -88,8 +104,8 @@ const PlayGamePage = () => {
   };
 
   useEffect(() => {
-    if (localStorage.getItem('localTeamId')) {
-      setMyTeamId(localStorage.getItem('localTeamId'));
+    if (getTeamCookie()) {
+      setMyTeamId(getTeamCookie());
     }
   }, []);
 
@@ -99,7 +115,6 @@ const PlayGamePage = () => {
         `/session/${sessionId}/status`,
         'GET'
       );
-      console.log(status.position, position);
       if (status.position !== position) {
         setIsTransition(true);
         await new Promise((r) => setTimeout(r, 500));
@@ -111,7 +126,7 @@ const PlayGamePage = () => {
       setQuestion(status.questions);
       setTeams(status.teams);
       if (!status.active) {
-        localStorage.removeItem('localTeamId');
+        deleteTeamCookie();
         alertCtx.info('This session has finished!');
       }
       setIsLoading(false);

--- a/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
@@ -33,7 +33,6 @@ const PlayGamePage = () => {
   );
   const alertCtx = useContext(AlertContext);
   const [quotable, setQuotable] = useState('');
-  const [selectedMarketIndex, setSelectedMarketIndex] = useState(0);
   const [isTransition, setIsTransition] = useState(false);
 
   // useEffect(() => {
@@ -263,9 +262,8 @@ const PlayGamePage = () => {
                   {question?.type === 'round' && (
                     <Typography sx={{ mt: 1 }} color="text.secondary">
                       Hint:{' '}
-                      {question?.round &&
-                      Object.values(question?.round)[selectedMarketIndex]
-                        ? Object.values(question?.round)[selectedMarketIndex]
+                      {question?.round && Object.values(question?.round)[0]
+                        ? Object.values(question?.round)[0]
                         : 'N/A'}
                     </Typography>
                   )}
@@ -369,13 +367,16 @@ const PlayGamePage = () => {
                           <Box
                             sx={{
                               display: 'flex',
-                              justifyContent: 'space-between',
+                              // justifyContent: 'space-between',
                               alignItems: 'flex-end',
                               mb: 1,
                             }}
                           >
                             <Typography fontSize={18}>{market}</Typography>
-                            <Typography color="text.secondary" sx={{ mr: 2 }}>
+                            <Typography
+                              color="text.secondary"
+                              sx={{ fontSize: 14, ml: 2 }}
+                            >
                               True Value $
                               {Object.values(question.round)[marketIndex]}
                             </Typography>

--- a/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
@@ -266,7 +266,7 @@ const PlayGamePage = () => {
                       {question?.round &&
                       Object.values(question?.round)[selectedMarketIndex]
                         ? Object.values(question?.round)[selectedMarketIndex]
-                        : 'No hint given'}
+                        : 'N/A'}
                     </Typography>
                   )}
                   <Divider sx={{ my: 3 }} />

--- a/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
@@ -57,7 +57,7 @@ const PlayGamePage = () => {
   const processResults = (teams) => {
     const teamResults = Object.keys(teams)
       .map((teamId, index) => {
-        const trueValue = question.trueValue;
+        const trueValue = Object.values(question.round)[selectedMarketIndex];
         const balance =
           teams[teamId].teamAnswers[position].markets[selectedMarketIndex]
             .balance;

--- a/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGamePage.jsx
@@ -17,6 +17,7 @@ import PriceChangeIcon from '@mui/icons-material/PriceChange';
 import TeamStats from '../GameHistoryPage/TeamStats';
 import { AlertContext } from '../../contexts/NotificationContext';
 import PlayGameTradeArea from './PlayGameTradeArea';
+import { GameTransition } from '../../components';
 
 const PlayGamePage = () => {
   const { sessionId } = useParams();
@@ -33,6 +34,14 @@ const PlayGamePage = () => {
   const alertCtx = useContext(AlertContext);
   const [quotable, setQuotable] = useState('');
   const [selectedMarketIndex, setSelectedMarketIndex] = useState(0);
+  const [isTransition, setIsTransition] = useState(false);
+
+  // useEffect(() => {
+  //   setIsTransition(true);
+  //   setTimeout(() => {
+  //     setIsTransition(false);
+  //   }, 750);
+  // }, [position]);
 
   const createTeam = async () => {
     const teamData = await fetchAPIRequest(`/game/join/${sessionId}`, 'POST', {
@@ -91,7 +100,15 @@ const PlayGamePage = () => {
         `/session/${sessionId}/status`,
         'GET'
       );
-      setPosition(status.position);
+      console.log(status.position, position);
+      if (status.position !== position) {
+        setIsTransition(true);
+        await new Promise((r) => setTimeout(r, 500));
+        setPosition(status.position);
+        setTimeout(() => {
+          setIsTransition(false);
+        }, 500);
+      }
       setQuestion(status.questions);
       setTeams(status.teams);
       if (!status.active) {
@@ -104,7 +121,7 @@ const PlayGamePage = () => {
       getGameStatus();
     }, 1000);
     return () => clearInterval(gameInterval);
-  }, [sessionId, alertCtx]);
+  }, [sessionId, alertCtx, position]);
 
   return (
     <Box
@@ -119,6 +136,7 @@ const PlayGamePage = () => {
         pt: 10,
       }}
     >
+      <GameTransition isTransition={isTransition} />
       <Box
         sx={{
           backgroundColor: '#fff',

--- a/frontend/src/pages/PlayGamePage/PlayGameTradeArea.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGameTradeArea.jsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import { BidAskPanel } from '../../components';
 
 const PlayGameTradeArea = ({
@@ -9,30 +8,26 @@ const PlayGameTradeArea = ({
   selectedMarketIndex,
 }) => {
   return (
-    <Box>
-      <BidAskPanel
-        position={position}
-        teamId={myTeamId}
-        teamName={teams[myTeamId]?.name}
-        balance={
-          teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex]
-            .balance
-        }
-        contracts={
-          teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex]
-            .contracts
-        }
-        lastBid={
-          teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex]
-            .bid
-        }
-        lastAsk={
-          teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex]
-            .ask
-        }
-        marketIndex={selectedMarketIndex}
-      />
-    </Box>
+    <BidAskPanel
+      position={position}
+      teamId={myTeamId}
+      teamName={teams[myTeamId]?.name}
+      balance={
+        teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex]
+          .balance
+      }
+      contracts={
+        teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex]
+          .contracts
+      }
+      lastBid={
+        teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex].bid
+      }
+      lastAsk={
+        teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex].ask
+      }
+      marketIndex={selectedMarketIndex}
+    />
   );
 };
 export default PlayGameTradeArea;

--- a/frontend/src/pages/PlayGamePage/PlayGameTradeArea.jsx
+++ b/frontend/src/pages/PlayGamePage/PlayGameTradeArea.jsx
@@ -1,0 +1,38 @@
+import { Box } from '@mui/material';
+import { BidAskPanel } from '../../components';
+
+const PlayGameTradeArea = ({
+  current,
+  position,
+  teams,
+  myTeamId,
+  selectedMarketIndex,
+}) => {
+  return (
+    <Box>
+      <BidAskPanel
+        position={position}
+        teamId={myTeamId}
+        teamName={teams[myTeamId]?.name}
+        balance={
+          teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex]
+            .balance
+        }
+        contracts={
+          teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex]
+            .contracts
+        }
+        lastBid={
+          teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex]
+            .bid
+        }
+        lastAsk={
+          teams[myTeamId]?.teamAnswers[position].markets[selectedMarketIndex]
+            .ask
+        }
+        marketIndex={selectedMarketIndex}
+      />
+    </Box>
+  );
+};
+export default PlayGameTradeArea;

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -2,5 +2,5 @@ export { default as LoginPage } from './LoginPage.jsx';
 export { default as RegisterPage } from './RegisterPage.jsx';
 export { default as Dashboard } from './Dashboard.jsx';
 export { default as EditGamePage } from './EditGamePage/EditGamePage.jsx';
-export { default as PlayGamePage } from './PlayGamePage.jsx';
-export { default as AdminSessionPage } from './AdminSessionPage.jsx';
+export { default as PlayGamePage } from './PlayGamePage/PlayGamePage.jsx';
+export { default as AdminSessionPage } from './AdminSessionPage/AdminSessionPage.jsx';

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -1,6 +1,6 @@
 export { default as LoginPage } from './LoginPage.jsx';
 export { default as RegisterPage } from './RegisterPage.jsx';
 export { default as Dashboard } from './Dashboard.jsx';
-export { default as EditGamePage } from './EditGamePage.jsx';
+export { default as EditGamePage } from './EditGamePage/EditGamePage.jsx';
 export { default as PlayGamePage } from './PlayGamePage.jsx';
 export { default as AdminSessionPage } from './AdminSessionPage.jsx';


### PR DESCRIPTION
This PR adds support for trading in multiple markets simultaneously. The admin of a game can specify optional markets for players to trade in. These markets are categorised into 'sections' and the players trade across a number of 'rounds'.
This PR also includes:
- Team ID management stored locally via a sessionID → teamID mapping within browser cookies
